### PR TITLE
Clamping changes to avoid numerical instability

### DIFF
--- a/jammy_flows/layers/spheres/sphere_base.py
+++ b/jammy_flows/layers/spheres/sphere_base.py
@@ -193,7 +193,13 @@ class sphere_base(layer_base.layer_base):
                 else:
 
                     # last one is 0 to 2pi
-                    new_angle=torch.acos(x[:,ind:ind+1]/torch.sum(x[:,ind:]**2, dim=1, keepdims=True).sqrt())
+                    # new_angle=torch.acos(x[:,ind:ind+1]/torch.sum(x[:,ind:]**2, dim=1, keepdims=True).sqrt())
+                    sq = torch.sum(x[:, ind:] ** 2, dim=1, keepdims=True)
+                    denom = torch.sqrt(torch.clamp(sq, min=1e-8))
+                    arg = x[:, ind:ind+1] / denom
+                    arg = torch.clamp(arg, -1.0, 1.0)
+                    new_angle = torch.acos(arg)
+
                     #mask_smaller=(x[:,ind+1:ind+2]<0).double()
                     new_angle=torch.where(x[:,ind+1:ind+2]<0, 2*numpy.pi-new_angle, new_angle)
 


### PR DESCRIPTION
Added small changes to eucl_to_spherical_embedding to guard against near-zero norms and floating point drift outside the domain of the acos function. Sometimes this previously lead to nan outputs.